### PR TITLE
Fix typo 'abilties'

### DIFF
--- a/Release/Changes.txt
+++ b/Release/Changes.txt
@@ -3472,7 +3472,7 @@ late Feb 2006 by lots of people
 19 August 2004 by Amadeus
 - Fixed ${Me.AltAbilityReady[]}
 - Fixed ${Me.AltAbilityTimer[]}
-- Added ${AltAbility[].MyReuseTime}  (proper reuse time if you hastened AA abilties)
+- Added ${AltAbility[].MyReuseTime}  (proper reuse time if you hastened AA abilities)
 - Added NEW COMMAND:  /aa
 *** Syntax ***
 /aa list all            -- lists all of your AA abilities in format [ID : name]


### PR DESCRIPTION
Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
should be 'abilities', you typed 'abilties'. I created this pull request to fix it!

If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
I’m aware of it.

Looking for the source code of this bot? Well, you have to be patient! The bot is under development
and I will publish the source code as soon as I’m finished with it.

With kind regards,
TheTypoMaster
